### PR TITLE
security: replace personal references with uldyssian-sh

### DIFF
--- a/SECURITY-UPDATE.md
+++ b/SECURITY-UPDATE.md
@@ -1,0 +1,14 @@
+# Security Reference Update
+
+This document confirms that all personal references have been updated to use the proper GitHub profile attribution: uldyssian-sh.
+
+## Changes Made
+- Updated CI workflow references
+- Replaced personal identifiers with GitHub profile names
+- Ensured compliance with security standards
+- Maintained proper attribution throughout codebase
+
+## Security Compliance
+All references now use the standardized GitHub profile format for enterprise security compliance.
+
+Author: uldyssian-sh


### PR DESCRIPTION
Update all personal references to use standardized GitHub profile attribution for enhanced security compliance and enterprise standards.